### PR TITLE
Fix/limit acc magnitude steer

### DIFF
--- a/cursor/alignment.go
+++ b/cursor/alignment.go
@@ -22,6 +22,6 @@ func (c Cursor) Align(radius float64, boids *[]*Cursor) vector.Vector {
 		alignmentSteer.Times(1.0 / float64(t))
 	}
 
-	alignmentSteer.Minus(&c.velocity)
+	alignmentSteer.Minus(&c.acceleration)
 	return alignmentSteer
 }

--- a/cursor/cursor.go
+++ b/cursor/cursor.go
@@ -30,15 +30,15 @@ func (c *Cursor) GetAcceleration() vector.Vector {
 	return c.acceleration
 }
 
-func (c *Cursor) SetPosition( pos *vector.Vector) {
+func (c *Cursor) SetPosition(pos *vector.Vector) {
 	c.position = *pos
 }
 
-func (c *Cursor) SetVelocity( v *vector.Vector) {
+func (c *Cursor) SetVelocity(v *vector.Vector) {
 	c.velocity = *v
 }
 
-func (c *Cursor) SetAcceleration( acc *vector.Vector) {
+func (c *Cursor) SetAcceleration(acc *vector.Vector) {
 	c.acceleration = *acc
 }
 
@@ -76,13 +76,13 @@ func (c Cursor) Update(deltaT, radius float64, boids *[]*Cursor, w, h int) *Curs
 // LimitAcceleration limits the magnitude of the acceleration vector
 func (c *Cursor) LimitAcceleration(magnitude float64) {
 	if c.acceleration.Distance() > magnitude {
-		c.acceleration.Times(magnitude/c.acceleration.Distance())
+		c.acceleration.Times(magnitude / c.acceleration.Distance())
 	}
 }
 
 // LimitVelocity limits the magnitude of the velocity vector
 func (c *Cursor) LimitVelocity(magnitude float64) {
 	if c.velocity.Distance() > magnitude {
-		c.velocity.Times(magnitude/c.velocity.Distance())
+		c.velocity.Times(magnitude / c.velocity.Distance())
 	}
 }

--- a/cursor/cursor.go
+++ b/cursor/cursor.go
@@ -42,10 +42,9 @@ func (c *Cursor) SetAcceleration(acc *vector.Vector) {
 	c.acceleration = *acc
 }
 
-func (c Cursor) Update(deltaT, radius float64, boids *[]*Cursor, w, h int) *Cursor {
+func (c Cursor) Update(deltaT, radius, accMagnitude, velMagnitude float64, boids *[]*Cursor, w, h int) *Cursor {
 	steer := c.Align(radius, boids)
 
-	c.acceleration.Times(0.5)
 	c.acceleration.Plus(&steer)
 
 	velocityIncrement := c.acceleration
@@ -69,6 +68,10 @@ func (c Cursor) Update(deltaT, radius float64, boids *[]*Cursor, w, h int) *Curs
 	if c.position.GetY() < 0 {
 		c.position.SetY(c.position.GetY() + float64(h))
 	}
+
+	// Limit both acceleration and velocity magnitudes.
+	c.LimitAcceleration(accMagnitude)
+	c.LimitVelocity(velMagnitude)
 
 	return &c
 }

--- a/cursor/cursor.go
+++ b/cursor/cursor.go
@@ -30,6 +30,18 @@ func (c *Cursor) GetAcceleration() vector.Vector {
 	return c.acceleration
 }
 
+func (c *Cursor) SetPosition( pos *vector.Vector) {
+	c.position = *pos
+}
+
+func (c *Cursor) SetVelocity( v *vector.Vector) {
+	c.velocity = *v
+}
+
+func (c *Cursor) SetAcceleration( acc *vector.Vector) {
+	c.acceleration = *acc
+}
+
 func (c Cursor) Update(deltaT, radius float64, boids *[]*Cursor, w, h int) *Cursor {
 	steer := c.Align(radius, boids)
 
@@ -59,4 +71,18 @@ func (c Cursor) Update(deltaT, radius float64, boids *[]*Cursor, w, h int) *Curs
 	}
 
 	return &c
+}
+
+// LimitAcceleration limits the magnitude of the acceleration vector
+func (c *Cursor) LimitAcceleration(magnitude float64) {
+	if c.acceleration.Distance() > magnitude {
+		c.acceleration.Times(magnitude/c.acceleration.Distance())
+	}
+}
+
+// LimitVelocity limits the magnitude of the velocity vector
+func (c *Cursor) LimitVelocity(magnitude float64) {
+	if c.velocity.Distance() > magnitude {
+		c.velocity.Times(magnitude/c.velocity.Distance())
+	}
 }

--- a/cursor/cursor_test.go
+++ b/cursor/cursor_test.go
@@ -1,0 +1,38 @@
+package cursor_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/MohamTahaB/goglide/cursor"
+)
+
+func TestLimitAcceleration(t *testing.T) {
+	magnitude := rand.Float64() * 100
+	c := cursor.RandomCursor(600, 600)
+
+	acc := c.GetAcceleration()
+	acc.Times(2 * magnitude)
+
+	c.SetAcceleration(&acc)
+	c.LimitAcceleration(magnitude)
+
+	if acc = c.GetAcceleration(); acc.Distance() > magnitude+1e-10 {
+		t.Errorf("limit acceleration test failed: expected a max magnitude of %f, got %f", magnitude, acc.Distance())
+	}
+}
+
+func TestLimitVelocity(t *testing.T) {
+	magnitude := rand.Float64() * 100
+	c := cursor.RandomCursor(600, 600)
+
+	v := c.GetVelocity()
+	v.Times(2 * magnitude)
+
+	c.SetVelocity(&v)
+	c.LimitVelocity(magnitude)
+
+	if v = c.GetVelocity(); v.Distance() > magnitude+1e-10 {
+		t.Errorf("limit velocity test failed: expected a max magnitude of %f, got %f", magnitude, v.Distance())
+	}
+}

--- a/model/model.go
+++ b/model/model.go
@@ -6,20 +6,23 @@ import (
 )
 
 type Model struct {
-	radius float64
-	boids  []*cursor.Cursor
+	velMagnitude, accMagnitude float64
+	radius                     float64
+	boids                      []*cursor.Cursor
 }
 
 // NewModel initiates a new model with given number of boids.
-func NewModel(number, w, h int, radius float64) *Model {
+func NewModel(number, w, h int, radius, accMagnitude, velMagnitude float64) *Model {
 	var boids []*cursor.Cursor
 	for i := 0; i < number; i++ {
 		boids = append(boids, cursor.RandomCursor(w, h))
 	}
 
 	return &Model{
-		radius: radius,
-		boids:  boids,
+		accMagnitude: accMagnitude,
+		velMagnitude: velMagnitude,
+		radius:       radius,
+		boids:        boids,
 	}
 }
 
@@ -33,7 +36,7 @@ func (m *Model) GetBoids() *[]*cursor.Cursor {
 func (m *Model) Update(deltaT float64, w, h int) {
 	var newBoids []*cursor.Cursor
 	for _, boid := range m.boids {
-		newBoids = append(newBoids, boid.Update(deltaT, m.radius, &m.boids, w, h))
+		newBoids = append(newBoids, boid.Update(deltaT, m.radius, m.accMagnitude, m.velMagnitude, &m.boids, w, h))
 	}
 
 	m.boids = newBoids

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -10,7 +10,7 @@ import (
 func TestNewModel(t *testing.T) {
 
 	number := rand.Intn(20) + 10
-	m := model.NewModel(number, 1920, 1080, 20)
+	m := model.NewModel(number, 1920, 1080, 20, 0, 0)
 	boids := m.GetBoids()
 
 	if boids == nil {

--- a/render/render.go
+++ b/render/render.go
@@ -15,6 +15,8 @@ const (
 	h                = 480
 	number           = 100
 	perceptionRadius = 20.0
+	accMagnitude     = 100
+	velMagnitude     = 150
 )
 
 type Render struct {
@@ -23,7 +25,7 @@ type Render struct {
 
 func InitiateRender() *Render {
 	return &Render{
-		m: model.NewModel(number, w, h, perceptionRadius),
+		m: model.NewModel(number, w, h, perceptionRadius, accMagnitude, velMagnitude),
 	}
 }
 


### PR DESCRIPTION
Limit velocity and acceleration magnitudes for the alignment steer to avoid some issues like slowing down or speeding considerably